### PR TITLE
Fixed improper usage of bigintegers, fixed subtraction and division

### DIFF
--- a/integers.go
+++ b/integers.go
@@ -17,7 +17,7 @@ func (f BoiFuncInt) Do(args []BoiVar) error {
 	defer f.interpreter.returnContext()
 
 	sum := new(big.Int)
-	sum = sum.SetUint64(0)
+	sum.SetUint64(0)
 
 	for _, arg := range args {
 		data := arg.data
@@ -27,7 +27,7 @@ func (f BoiFuncInt) Do(args []BoiVar) error {
 		}
 		tmp := new(big.Int)
 		tmp.SetUint64(value)
-		sum = sum.Add(sum, tmp)
+		sum.Add(sum, tmp)
 	}
 
 	context.variables["exit"] = BoiVar{sum.Bytes()}
@@ -43,11 +43,11 @@ func (f BoiFuncAdd) Do(args []BoiVar) error {
 	defer f.interpreter.returnContext()
 
 	sum := new(big.Int)
-	sum = sum.SetUint64(0)
+	sum.SetUint64(0)
 	for _, arg := range args {
 		tmp := new(big.Int)
-		tmp = tmp.SetBytes(arg.data)
-		sum = sum.Add(sum, tmp)
+		tmp.SetBytes(arg.data)
+		sum.Add(sum, tmp)
 	}
 
 	context.variables["exit"] = BoiVar{sum.Bytes()}
@@ -63,11 +63,11 @@ func (f BoiFuncSub) Do(args []BoiVar) error {
 	defer f.interpreter.returnContext()
 
 	sum := new(big.Int)
-	sum = sum.SetUint64(0)
-	for _, arg := range args {
+	sum.SetBytes(args[0].data)
+	for _, arg := range args[1:] {
 		tmp := new(big.Int)
-		tmp = tmp.SetBytes(arg.data)
-		sum = sum.Sub(sum, tmp)
+		tmp.SetBytes(arg.data)
+		sum.Sub(sum, tmp)
 	}
 
 	context.variables["exit"] = BoiVar{sum.Bytes()}
@@ -83,11 +83,11 @@ func (f BoiFuncDiv) Do(args []BoiVar) error {
 	defer f.interpreter.returnContext()
 
 	sum := new(big.Int)
-	sum = sum.SetUint64(0)
-	for _, arg := range args {
+	sum.SetBytes(args[0].data)
+	for _, arg := range args[1:] {
 		tmp := new(big.Int)
-		tmp = tmp.SetBytes(arg.data)
-		sum = sum.Div(sum, tmp)
+		tmp.SetBytes(arg.data)
+		sum.Div(sum, tmp)
 	}
 
 	context.variables["exit"] = BoiVar{sum.Bytes()}
@@ -106,8 +106,8 @@ func (f BoiFuncMul) Do(args []BoiVar) error {
 	sum = sum.SetUint64(1)
 	for _, arg := range args {
 		tmp := new(big.Int)
-		tmp = tmp.SetBytes(arg.data)
-		sum = sum.Mul(sum, tmp)
+		tmp.SetBytes(arg.data)
+		sum.Mul(sum, tmp)
 	}
 
 	context.variables["exit"] = BoiVar{sum.Bytes()}


### PR DESCRIPTION
Fixes:
1. Removes unnecessary assignments when using class methods (eg `c = c.Add(A,B) --> c.Add(A,B)`)
2. Initializes result variable with minuend or dividend instead of zero

Basic tests have been done with the following code:
```
boi, "Subtraction" boi
boi, "10 == " [dec [- [int 13] [int 3]]] boi
boi, "7 == " [dec [- [int 13] [int 3] [int 3]]] boi
boi, "-5 == " [dec [- [int 8] [int 13]]] boi
boi, "-5 == " [dec [- [int 8] [int 8] [int 5]]] boi
boi, "(No signed number support)" boi
boi, "Addition" boi
boi, "16 == " [dec [+ [int 13] [int 3]]] boi
boi, "25 == " [dec [+ [int 9] [int 1] [int 5] [int 10]]] boi
boi, "Multiplication" boi
boi, "27 == " [dec [* [int 9] [int 3]]] boi
boi, "135 == " [dec [* [int 9] [int 3] [int 5]]] boi
boi, "8582777280 == " [dec [* [int 99] [int 98] [int 97] [int 96] [int 95]]] boi
boi, "Division" boi
boi, "3 == " [dec [/ [int 9] [int 3]]] boi
boi, "3 == " [dec [/ [int 10] [int 3]]] boi
boi, "3 == " [dec [/ [int 27] [int 3] [int 3]]] boi
boi, "Looking good boi" boi
```

Results:

```
Subtraction
10 == 10
7 == 7
-5 == 5
-5 == 5
(No signed number support)
Addition
16 == 16
25 == 25
Multiplication
27 == 27
135 == 135
8582777280 == 8582777280
Division
3 == 3
3 == 3
3 == 3
Looking good boi
```